### PR TITLE
Add Buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,27 @@ inp.home()
 inp.back()
 inp.dash()
 inp.info()
+inp.num_1()         # Number keys...
+inp.num_2()
+inp.num_3()
+inp.num_4()
+inp.num_5()
+inp.num_6()
+inp.num_7()
+inp.num_8()
+inp.num_9()
+inp.num_0()
+inp.asterisk()      # Literally just an "*"
+inp.cc()            # Closed captioning
+inp.exit()          
+inp.red()           # Colored buttons
+inp.green()
+inp.blue()
+inp.mute()          # The remaining commands are also available in either MediaControl or TvControl
+inp.volume_up()
+inp.volume_down()
+inp.channel_up()
+inp.channel_down()
 inp.disconnect_input()
 ```
 

--- a/pywebostv/controls.py
+++ b/pywebostv/controls.py
@@ -298,6 +298,69 @@ class InputControl(WebOSControlBase):
         "info": {
             "command": [["type", "button"], ["name", "INFO"]]
         },
+        "one": {
+            "command": [["type", "button"], ["name", "1"]]
+        },
+        "two": {
+            "command": [["type", "button"], ["name", "2"]]
+        },
+        "three": {
+            "command": [["type", "button"], ["name", "3"]]
+        },
+        "four": {
+            "command": [["type", "button"], ["name", "4"]]
+        },
+        "five": {
+            "command": [["type", "button"], ["name", "5"]]
+        },
+        "six": {
+            "command": [["type", "button"], ["name", "6"]]
+        },
+        "seven": {
+            "command": [["type", "button"], ["name", "7"]]
+        },
+        "eight": {
+            "command": [["type", "button"], ["name", "8"]]
+        },
+        "nine": {
+            "command": [["type", "button"], ["name", "9"]]
+        },
+        "zero": {
+            "command": [["type", "button"], ["name", "0"]]
+        },
+        "asterisk": {
+            "command": [["type", "button"], ["name", "ASTERISK"]]
+        },
+        "cc": {
+            "command": [["type", "button"], ["name", "CC"]]
+        },
+        "exit": {
+            "command": [["type", "button"], ["name", "EXIT"]]
+        },
+        "mute": {
+            "command": [["type", "button"], ["name", "MUTE"]]
+        },
+        "red": {
+            "command": [["type", "button"], ["name", "RED"]]
+        },
+        "green": {
+            "command": [["type", "button"], ["name", "GREEN"]]
+        },
+        "blue": {
+            "command": [["type", "button"], ["name", "BLUE"]]
+        },
+        "volume_up": {
+            "command": [["type", "button"], ["name", "VOLUMEUP"]]
+        },
+        "volume_down": {
+            "command": [["type", "button"], ["name", "VOLUMEDOWN"]]
+        },
+        "channel_up": {
+            "command": [["type", "button"], ["name", "CHANNELUP"]]
+        },
+        "channel_down": {
+            "command": [["type", "button"], ["name", "CHANNELDOWN"]]
+        },
     }
 
     def __init__(self, *args, **kwargs):

--- a/pywebostv/controls.py
+++ b/pywebostv/controls.py
@@ -298,34 +298,34 @@ class InputControl(WebOSControlBase):
         "info": {
             "command": [["type", "button"], ["name", "INFO"]]
         },
-        "one": {
+        "num_1": {
             "command": [["type", "button"], ["name", "1"]]
         },
-        "two": {
+        "num_2": {
             "command": [["type", "button"], ["name", "2"]]
         },
-        "three": {
+        "num_3": {
             "command": [["type", "button"], ["name", "3"]]
         },
-        "four": {
+        "num_4": {
             "command": [["type", "button"], ["name", "4"]]
         },
-        "five": {
+        "num_5": {
             "command": [["type", "button"], ["name", "5"]]
         },
-        "six": {
+        "num_6": {
             "command": [["type", "button"], ["name", "6"]]
         },
-        "seven": {
+        "num_7": {
             "command": [["type", "button"], ["name", "7"]]
         },
-        "eight": {
+        "num_8": {
             "command": [["type", "button"], ["name", "8"]]
         },
-        "nine": {
+        "num_9": {
             "command": [["type", "button"], ["name", "9"]]
         },
-        "zero": {
+        "num_0": {
             "command": [["type", "button"], ["name", "0"]]
         },
         "asterisk": {


### PR DESCRIPTION
Found more buttons in the WebOS projects listed [here](https://github.com/vitalets/awesome-smart-tv/blob/master/README.md#lg-webos). 

- one
- two
- three
- four
- five
- six
- seven
- eight
- nine
- zero
- asterisk
- cc
- exit
- mute
- red
- green
- blue
- volume_up
- volume_down
- channel_up
- channel_down