### PR TITLE
Added IOError for e.g. unauthorized error

### DIFF
--- a/pywebostv/controls.py
+++ b/pywebostv/controls.py
@@ -119,6 +119,8 @@ class WebOSControlBase(object):
             elif block:
                 res = self.request(cmd_info["uri"], params, block=block,
                                    timeout=timeout)
+                if res.get("type",None) == "error":
+                    raise IOError(res.get("error","Unknown Error(2)"))
                 payload = res.get("payload")
                 status, message = response_valid(payload)
                 if not status:


### PR DESCRIPTION
Some errors are not contained inside the payload, but are directly in the response (e.g. '401 insufficient permissions (not registered)')
These errors pop up in response_valid as "Unknown Error" and the real reason is lost.