### PR TITLE
Added functionality for setting backlight intensity

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,4 +325,6 @@ A tiny side note: What `client.register(..)` expects is an object with `__getite
    implementation
 - As far as input controls are concerned, they are based on the Java package written by
    [Connect-SDK folks](https://github.com/ConnectSDK/Connect-SDK-Android-Core/tree/master/src/com/connectsdk/service/webos)!
+- Bendavid for the inspiration for the lunahack addon https://github.com/bendavid/aiopylgtv
 - All individual contributors to this repository.
+

--- a/pywebostv/LunaHack.py
+++ b/pywebostv/LunaHack.py
@@ -1,0 +1,34 @@
+# Function to run luna commands that are normally blocked. Got heavy inspiration from https://github.com/bendavid/aiopylgtv
+
+from pywebostv.controls import WebOSControlBase, process_payload
+
+original_exec_command = WebOSControlBase.exec_command
+
+def LunaHack(self, cmd, cmd_info):
+    if "luna://" in cmd_info["uri"]:
+        def lunaCommand(*args,**kwargs):
+            cmd_info["payload"] = process_payload(cmd_info.get("payload"), *args, **kwargs)
+            payload = {
+                "uri":"ssap://system.notifications/createAlert",
+                "payload":{
+                        "message": " ",
+                        "buttons": [{"label": "", "onClick": cmd_info["uri"], "params": cmd_info["payload"]}],
+                        "onclose": {"uri": cmd_info["uri"], "params": cmd_info["payload"]},
+                        "onfail":  {"uri": cmd_info["uri"], "params": cmd_info["payload"]},
+                    },
+                }
+            alertId = original_exec_command(self,"blank",payload)()["alertId"]
+            payload = {
+                "uri":"ssap://system.notifications/closeAlert",
+                "payload":{
+                    "alertId": alertId
+                    }
+                }
+            original_exec_command(self,"blank",payload)()
+            return None
+        return lunaCommand
+    else:
+        return original_exec_command(self, cmd, cmd_info)
+
+WebOSControlBase.exec_command = LunaHack
+'

--- a/pywebostv/extraControls.py
+++ b/pywebostv/extraControls.py
@@ -1,0 +1,27 @@
+from pywebostv.controls import *
+from pywebostv.lunaHack import *
+
+# Adds functions to read from and write to screen brightness. Uses LunaHack.py
+
+class PictureControl(WebOSControlBase):
+    COMMANDS = {
+        "get_backlight": {
+            "uri": "SSAP://settings/getSystemSettings",
+            "payload":{
+                "category": "picture",
+                "keys": ["brightness"]
+            },
+            "validation": standard_validation,
+            "return": lambda p: p['settings']['brightness'],
+        },
+        "set_backlight": {
+            "uri": "luna://com.webos.settingsservice/setSystemSettings",
+            #"args": [int],
+            "payload": {
+                "category": "picture",
+                "settings": {"backlight":arguments(0)}
+            },
+            "validation": standard_validation,
+            "return": lambda p: [p],
+        },
+    }


### PR DESCRIPTION
https://github.com/bendavid/aiopylgtv found a workaround to access luna URI's that are usually hidden.
I made a script that adds onto, without changing the functionality that is already there. Basically, whever "lunahack.py" is included, it adds on to the "exec_command" function within "WebOSControlBase". Whenever the uri that's given in controls.py contains "luna://" it kicks in, and handles it with the luna hack. Otherwise, it'll behave the same as original.

Feel free to do with this whatever you want, but I think some other people might like this functionality. If this isn't the way to handle pull requests, please tell me; this is my first time ever working with github :'D