### PR TITLE
Fix MediaControl subscribe_get_audio_output and TVControl subscribe_get_current_channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,20 @@ media.subscribe_get_volume(on_volume_change)  # on_volume_change(..) will now be
                                               # volume/mute status etc changes.
 ```
 
+`get_audio_output` also supports subscription. To subscribe to audio output changes you may use something like:
+
+```python
+def on_audio_output_change(status, payload):
+    if status:
+        print(payload)
+    else:
+        print("Something went wrong.")
+
+media.subscribe_get_audio_output(on_audio_output_change)  # on_audio_output_change(..) will now be called when the
+                                                          # output changes, for example connecting/disconneting a
+                                                          # bluetooth headphone device.
+```
+
 ### System Controls
 
 ```python

--- a/pywebostv/controls.py
+++ b/pywebostv/controls.py
@@ -140,7 +140,10 @@ class WebOSControlBase(object):
 
     def subscribe(self, name, cmd_info):
         def request_func(callback):
-            response_valid = cmd_info.get("validation", lambda p: (True, None))
+            response_valid = cmd_info.get(
+                "subscription_validation",
+                cmd_info.get("validation", lambda p: (True, None))
+            )
             return_fn = cmd_info.get('return', lambda x: x)
 
             def callback_wrapper(payload):
@@ -198,7 +201,8 @@ class MediaControl(WebOSControlBase):
         "fast_forward": {"uri": "ssap://media.controls/fastForward"},
         "get_audio_output": {
             "uri": "ssap://audio/getSoundOutput",
-            "validation": subscription_validation,
+            "validation": standard_validation,
+            "subscription_validation": subscription_validation,
             "subscription": True,
             "return": lambda p: AudioOutputSource(p["soundOutput"])
         },

--- a/pywebostv/controls.py
+++ b/pywebostv/controls.py
@@ -54,7 +54,11 @@ def standard_validation(payload, key="returnValue"):
 
 
 def subscription_validation(payload):
-    return standard_validation(payload, "subscribed")
+    for key in {"subscribed", "returnValue"}:
+        status, error_text = standard_validation(payload, key)
+        if status:
+            break
+    return status, error_text
 
 
 class WebOSControlBase(object):
@@ -140,10 +144,7 @@ class WebOSControlBase(object):
 
     def subscribe(self, name, cmd_info):
         def request_func(callback):
-            response_valid = cmd_info.get(
-                "subscription_validation",
-                cmd_info.get("validation", lambda p: (True, None))
-            )
+            response_valid = cmd_info.get("subscription_validation", lambda p: (True, None))
             return_fn = cmd_info.get('return', lambda x: x)
 
             def callback_wrapper(payload):
@@ -182,6 +183,7 @@ class MediaControl(WebOSControlBase):
         "get_volume": {
             "uri": "ssap://audio/getVolume",
             "validation": standard_validation,
+            "subscription_validation": subscription_validation,
             "subscription": True,
         },
         "set_volume": {
@@ -299,6 +301,7 @@ class ApplicationControl(WebOSControlBase):
             "kwargs": {},
             "payload": {},
             "validation": standard_validation,
+            "subscription_validation": subscription_validation,
             "return": lambda p: p["appId"],
             "subscription": True,
         },

--- a/pywebostv/controls.py
+++ b/pywebostv/controls.py
@@ -232,6 +232,7 @@ class TvControl(WebOSControlBase):
         "get_current_channel": {
             "uri": "ssap://tv/getCurrentChannel",
             "validation": standard_validation,
+            "subscription_validation": subscription_validation,
             "subscription": True
         },
         "channel_list": {"uri": "ssap://tv/getChannelList"},

--- a/pywebostv/controls.py
+++ b/pywebostv/controls.py
@@ -47,10 +47,14 @@ def process_payload(obj, *args, **kwargs):
         return obj
 
 
-def standard_validation(payload):
-    if not payload.pop("returnValue", None):
+def standard_validation(payload, key="returnValue"):
+    if not payload.pop(key, None):
         return False, payload.pop("errorText", "Unknown error.")
     return True, None
+
+
+def subscription_validation(payload):
+    return standard_validation(payload, "subscribed")
 
 
 class WebOSControlBase(object):
@@ -194,7 +198,7 @@ class MediaControl(WebOSControlBase):
         "fast_forward": {"uri": "ssap://media.controls/fastForward"},
         "get_audio_output": {
             "uri": "ssap://audio/getSoundOutput",
-            "validation": standard_validation,
+            "validation": subscription_validation,
             "subscription": True,
             "return": lambda p: AudioOutputSource(p["soundOutput"])
         },

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
 
 setup(
     name='pywebostv',
-    version='0.8.9',
+    version='0.8.10',
     url='https://github.com/supersaiyanmode/PyWebOSTV',
     author='Srivatsan Iyer',
     author_email='supersaiyanmode.rox@gmail.com',

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -170,7 +170,7 @@ class TestWebOSControlBase(object):
             "test": {
                 "uri": "/test",
                 "subscription": True,
-                "validation": lambda p: (p == {"a": 1}, "Error.")
+                "subscription_validation": lambda p: (p == {"a": 1}, "Error.")
             },
         }
 


### PR DESCRIPTION
Hello:

This PR fixes the subscription to `get_audio_output` of `MediaControl`.

In the original code, these are always the values whenever the callback gets called:
* `status`: `False`
* `payload`: `Unknown Error`

This is because of the `standard_validation` checks for the key `errorText` that is never present as the TV returns a response like (so `subscribed` is checked instead) :

```
{"type":"response","id":"...","payload":{"soundOutput":"tv_speaker","subscribed":true}}
```

*PS: While this was tested on the latest WebOS 2023, this should affect any WebOS version, since I checked the api version is still 1 for the audio endpoint* 

Thanks for the great project ;)


